### PR TITLE
refactor(queries): Introduce ratings on read/query methods

### DIFF
--- a/backend/src/main/layers/application/queries/get-post.query.ts
+++ b/backend/src/main/layers/application/queries/get-post.query.ts
@@ -1,8 +1,16 @@
-import type { GetPostData } from "@domain/usecases/get-post.contract";
+import type {
+  GetPostData,
+  GetPostRatings,
+} from "@domain/usecases/get-post.contract";
+
+export type GetPostDetails = {
+  post: GetPostData;
+  ratings: GetPostRatings;
+};
 
 export interface GetPostQuery {
   findPostDetailsById(
     post_id: string,
     viewer_id?: string,
-  ): Promise<GetPostData | null>;
+  ): Promise<GetPostDetails | null>;
 }

--- a/backend/src/main/layers/application/usecases/get-post.usecase.ts
+++ b/backend/src/main/layers/application/usecases/get-post.usecase.ts
@@ -18,12 +18,12 @@ export class GetPostUseCase implements GetPost {
     const commentsLimit = data.limit;
     const commentsCursor = data.cursor;
 
-    const post = await this.getPostQuery.findPostDetailsById(
+    const postDetails = await this.getPostQuery.findPostDetailsById(
       data.post_id,
       data.viewer_id,
     );
 
-    if (!post) {
+    if (!postDetails) {
       throw new AppError("NOT_FOUND", "The specified post does not exist.");
     }
 
@@ -42,7 +42,8 @@ export class GetPostUseCase implements GetPost {
       : null;
 
     return {
-      post,
+      post: postDetails.post,
+      ratings: postDetails.ratings,
       comments: paginatedComments,
       pagination: {
         limit: commentsLimit,

--- a/backend/src/main/layers/domain/usecases/get-feed.contract.ts
+++ b/backend/src/main/layers/domain/usecases/get-feed.contract.ts
@@ -14,6 +14,7 @@ export type FeedItem = {
     id: string;
     name: string;
     type: PetType;
+    ratings_count: number;
   };
   author: {
     id: string;

--- a/backend/src/main/layers/domain/usecases/get-me.contract.ts
+++ b/backend/src/main/layers/domain/usecases/get-me.contract.ts
@@ -10,6 +10,7 @@ export type GetMePet = {
   name: string;
   type: PetType;
   imageUrl: string;
+  ratingsCount: number;
 };
 
 export type GetMeProfile = {

--- a/backend/src/main/layers/domain/usecases/get-post.contract.ts
+++ b/backend/src/main/layers/domain/usecases/get-post.contract.ts
@@ -21,6 +21,18 @@ export type GetPostData = {
   viewer_has_liked: boolean;
 };
 
+export type GetPostRatings = {
+  total_count: number;
+  by_rate: {
+    cute: number;
+    funny: number;
+    majestic: number;
+    chaos: number;
+    smart: number;
+    sleepy: number;
+  };
+};
+
 export interface GetPostDTO {
   post_id: string;
   viewer_id?: string;
@@ -30,6 +42,7 @@ export interface GetPostDTO {
 
 export type GetPostResult = {
   post: GetPostData;
+  ratings: GetPostRatings;
   comments: GetPostComment[];
   pagination: {
     limit: number;

--- a/backend/src/main/layers/domain/usecases/get-profile.contract.ts
+++ b/backend/src/main/layers/domain/usecases/get-profile.contract.ts
@@ -10,6 +10,7 @@ export type GetProfilePet = {
   name: string;
   type: PetType;
   imageUrl: string;
+  ratingsCount: number;
 };
 
 export type GetProfileData = {

--- a/backend/src/main/layers/infra/db/postgres/queries/pg-feed.query.ts
+++ b/backend/src/main/layers/infra/db/postgres/queries/pg-feed.query.ts
@@ -13,6 +13,7 @@ type FeedRow = {
   pet_id: string;
   pet_name: string;
   pet_type: FeedItem["pet"]["type"];
+  pet_ratings_count: number;
   author_id: string;
   author_name: string;
   likes_count: number;
@@ -45,6 +46,7 @@ export class PgFeedQuery implements GetFeedQuery {
         id: feedRow.pet_id,
         name: feedRow.pet_name,
         type: feedRow.pet_type,
+        ratings_count: feedRow.pet_ratings_count,
       },
       author: {
         id: feedRow.author_id,

--- a/backend/src/main/layers/infra/db/postgres/queries/pg-me.query.ts
+++ b/backend/src/main/layers/infra/db/postgres/queries/pg-me.query.ts
@@ -20,6 +20,7 @@ type MePetRow = {
   name: string;
   type: GetMePet["type"];
   image_url: string;
+  ratings_count: number;
 };
 
 export class PgMeQuery implements GetMeProfileQuery, GetMePetsQuery {
@@ -64,6 +65,7 @@ export class PgMeQuery implements GetMeProfileQuery, GetMePetsQuery {
       name: petRow.name,
       type: petRow.type,
       imageUrl: petRow.image_url,
+      ratingsCount: petRow.ratings_count,
     }));
   }
 }

--- a/backend/src/main/layers/infra/db/postgres/queries/pg-post.query.ts
+++ b/backend/src/main/layers/infra/db/postgres/queries/pg-post.query.ts
@@ -1,4 +1,7 @@
-import type { GetPostQuery } from "@application/queries/get-post.query";
+import type {
+  GetPostDetails,
+  GetPostQuery,
+} from "@application/queries/get-post.query";
 import type {
   FindPostCommentsInput,
   GetCommentsQuery,
@@ -7,6 +10,7 @@ import type { PostExistsQuery } from "@application/queries/post-exists.query";
 import type {
   GetPostComment,
   GetPostData,
+  GetPostRatings,
 } from "@domain/usecases/get-post.contract";
 import { PgPool } from "../helpers/pg-pool";
 import { sql } from "../sql/post.query.sql";
@@ -21,6 +25,13 @@ type PostDetailsRow = {
   likes_count: number;
   comments_count: number;
   viewer_has_liked: boolean;
+  ratings_total_count: number;
+  cute_count: number;
+  funny_count: number;
+  majestic_count: number;
+  chaos_count: number;
+  smart_count: number;
+  sleepy_count: number;
 };
 
 type PostCommentRow = {
@@ -57,7 +68,7 @@ export class PgPostQuery
   async findPostDetailsById(
     post_id: string,
     viewer_id?: string,
-  ): Promise<GetPostData | null> {
+  ): Promise<GetPostDetails | null> {
     const postRows = await this.pool.query<PostDetailsRow>(
       sql.FIND_POST_DETAILS_BY_ID,
       [post_id, viewer_id ?? null],
@@ -68,16 +79,31 @@ export class PgPostQuery
       return null;
     }
 
+    const ratings: GetPostRatings = {
+      total_count: post.ratings_total_count,
+      by_rate: {
+        cute: post.cute_count,
+        funny: post.funny_count,
+        majestic: post.majestic_count,
+        chaos: post.chaos_count,
+        smart: post.smart_count,
+        sleepy: post.sleepy_count,
+      },
+    };
+
     return {
-      id: post.id,
-      pet_id: post.pet_id,
-      author_id: post.author_id,
-      caption: post.caption,
-      status: post.status,
-      created_at: post.created_at,
-      likes_count: post.likes_count,
-      comments_count: post.comments_count,
-      viewer_has_liked: post.viewer_has_liked,
+      post: {
+        id: post.id,
+        pet_id: post.pet_id,
+        author_id: post.author_id,
+        caption: post.caption,
+        status: post.status,
+        created_at: post.created_at,
+        likes_count: post.likes_count,
+        comments_count: post.comments_count,
+        viewer_has_liked: post.viewer_has_liked,
+      },
+      ratings,
     };
   }
 

--- a/backend/src/main/layers/infra/db/postgres/queries/pg-profile.query.ts
+++ b/backend/src/main/layers/infra/db/postgres/queries/pg-profile.query.ts
@@ -22,6 +22,7 @@ type ProfilePetRow = {
   name: string;
   type: GetProfilePet["type"];
   image_url: string;
+  ratings_count: number;
 };
 
 export class PgProfileQuery
@@ -67,6 +68,7 @@ export class PgProfileQuery
       name: petRow.name,
       type: petRow.type,
       imageUrl: petRow.image_url,
+      ratingsCount: petRow.ratings_count,
     }));
   }
 }

--- a/backend/src/main/layers/infra/db/postgres/sql/feed.query.sql.ts
+++ b/backend/src/main/layers/infra/db/postgres/sql/feed.query.sql.ts
@@ -7,6 +7,7 @@ export const sql = {
     pet.id AS pet_id,
     pet.name AS pet_name,
     pet.type AS pet_type,
+    COALESCE(ratings.ratings_count, 0)::int AS pet_ratings_count,
     u.id AS author_id,
     u.name AS author_name,
     p.likes_count,
@@ -25,6 +26,11 @@ export const sql = {
   FROM posts p
   INNER JOIN users u ON u.id = p.author_id
   INNER JOIN pets pet ON pet.id = p.pet_id
+  LEFT JOIN LATERAL (
+    SELECT COUNT(*)::int AS ratings_count
+    FROM ratings r
+    WHERE r.pet_id = pet.id
+  ) ratings ON TRUE
   WHERE p.status = 'PUBLISHED'
     AND (
       $1::timestamptz IS NULL

--- a/backend/src/main/layers/infra/db/postgres/sql/me.query.sql.ts
+++ b/backend/src/main/layers/infra/db/postgres/sql/me.query.sql.ts
@@ -21,8 +21,14 @@ export const sql = {
     id,
     name,
     type,
-    image_url
+    image_url,
+    COALESCE(ratings.ratings_count, 0)::int AS ratings_count
   FROM pets
+  LEFT JOIN LATERAL (
+    SELECT COUNT(*)::int AS ratings_count
+    FROM ratings r
+    WHERE r.pet_id = pets.id
+  ) ratings ON TRUE
   WHERE owner_id = $1
     AND deleted_at IS NULL
   ORDER BY created_at ASC, id ASC

--- a/backend/src/main/layers/infra/db/postgres/sql/post.query.sql.ts
+++ b/backend/src/main/layers/infra/db/postgres/sql/post.query.sql.ts
@@ -17,6 +17,13 @@ export const sql = {
     p.created_at,
     p.likes_count,
     p.comments_count,
+    COALESCE(ratings.total_count, 0)::int AS ratings_total_count,
+    COALESCE(ratings.cute_count, 0)::int AS cute_count,
+    COALESCE(ratings.funny_count, 0)::int AS funny_count,
+    COALESCE(ratings.majestic_count, 0)::int AS majestic_count,
+    COALESCE(ratings.chaos_count, 0)::int AS chaos_count,
+    COALESCE(ratings.smart_count, 0)::int AS smart_count,
+    COALESCE(ratings.sleepy_count, 0)::int AS sleepy_count,
     (
       $2::uuid IS NOT NULL
       AND EXISTS (
@@ -27,6 +34,18 @@ export const sql = {
       )
     ) AS viewer_has_liked
   FROM posts p
+  LEFT JOIN LATERAL (
+    SELECT
+      COUNT(*)::int AS total_count,
+      COUNT(*) FILTER (WHERE r.rate = 'cute')::int AS cute_count,
+      COUNT(*) FILTER (WHERE r.rate = 'funny')::int AS funny_count,
+      COUNT(*) FILTER (WHERE r.rate = 'majestic')::int AS majestic_count,
+      COUNT(*) FILTER (WHERE r.rate = 'chaos')::int AS chaos_count,
+      COUNT(*) FILTER (WHERE r.rate = 'smart')::int AS smart_count,
+      COUNT(*) FILTER (WHERE r.rate = 'sleepy')::int AS sleepy_count
+    FROM ratings r
+    WHERE r.pet_id = p.pet_id
+  ) ratings ON TRUE
   WHERE p.id = $1
     AND p.status = 'PUBLISHED'
   `,

--- a/backend/src/main/layers/infra/db/postgres/sql/profile.query.sql.ts
+++ b/backend/src/main/layers/infra/db/postgres/sql/profile.query.sql.ts
@@ -20,8 +20,14 @@ export const sql = {
     id,
     name,
     type,
-    image_url
+    image_url,
+    COALESCE(ratings.ratings_count, 0)::int AS ratings_count
   FROM pets
+  LEFT JOIN LATERAL (
+    SELECT COUNT(*)::int AS ratings_count
+    FROM ratings r
+    WHERE r.pet_id = pets.id
+  ) ratings ON TRUE
   WHERE owner_id = $1
     AND deleted_at IS NULL
   ORDER BY created_at ASC, id ASC

--- a/backend/tests/application/doubles/get-feed.query.stub.ts
+++ b/backend/tests/application/doubles/get-feed.query.stub.ts
@@ -16,6 +16,7 @@ export class GetFeedQueryStub implements GetFeedQuery {
           id: "valid_pet_id",
           name: "valid_pet_name",
           type: "dog",
+          ratings_count: 4,
         },
         author: {
           id: "valid_author_id",

--- a/backend/tests/application/doubles/get-me-pets.query.stub.ts
+++ b/backend/tests/application/doubles/get-me-pets.query.stub.ts
@@ -8,6 +8,7 @@ export class GetMePetsQueryStub implements GetMePetsQuery {
         name: "valid_pet_name",
         type: "dog" as const,
         imageUrl: "https://valid.image/pet.png",
+        ratingsCount: 4,
       },
     ];
   }

--- a/backend/tests/application/doubles/get-post.query.stub.ts
+++ b/backend/tests/application/doubles/get-post.query.stub.ts
@@ -1,22 +1,37 @@
-import type { GetPostQuery } from "@application/queries/get-post.query";
-import type { GetPostData } from "@domain/usecases/get-post.contract";
+import type {
+  GetPostDetails,
+  GetPostQuery,
+} from "@application/queries/get-post.query";
 import { FIXED_DATE } from "../../config/constants";
 
 export class GetPostQueryStub implements GetPostQuery {
   async findPostDetailsById(
     post_id: string,
     viewer_id?: string,
-  ): Promise<GetPostData | null> {
+  ): Promise<GetPostDetails | null> {
     return {
-      id: post_id,
-      pet_id: "valid_pet_id",
-      author_id: "valid_author_id",
-      caption: "valid_caption",
-      status: "PUBLISHED",
-      created_at: FIXED_DATE,
-      likes_count: 1,
-      comments_count: 1,
-      viewer_has_liked: viewer_id === "valid_viewer_id",
+      post: {
+        id: post_id,
+        pet_id: "valid_pet_id",
+        author_id: "valid_author_id",
+        caption: "valid_caption",
+        status: "PUBLISHED",
+        created_at: FIXED_DATE,
+        likes_count: 1,
+        comments_count: 1,
+        viewer_has_liked: viewer_id === "valid_viewer_id",
+      },
+      ratings: {
+        total_count: 4,
+        by_rate: {
+          cute: 1,
+          funny: 1,
+          majestic: 1,
+          chaos: 0,
+          smart: 1,
+          sleepy: 0,
+        },
+      },
     };
   }
 }

--- a/backend/tests/application/doubles/get-profile-pets.query.stub.ts
+++ b/backend/tests/application/doubles/get-profile-pets.query.stub.ts
@@ -8,6 +8,7 @@ export class GetProfilePetsQueryStub implements GetProfilePetsQuery {
         name: "valid_pet_name",
         type: "dog" as const,
         imageUrl: "https://valid.image/pet.png",
+        ratingsCount: 4,
       },
     ];
   }

--- a/backend/tests/application/get-feed.usecase.spec.ts
+++ b/backend/tests/application/get-feed.usecase.spec.ts
@@ -32,6 +32,7 @@ describe("GetFeedUseCase", () => {
       id: "valid_pet_id",
       name: "valid_pet_name",
       type: "dog" as "dog" | "cat",
+      ratings_count: 4,
     },
     author: {
       id: "valid_author_id",
@@ -68,6 +69,14 @@ describe("GetFeedUseCase", () => {
       has_more: false,
       next_cursor: null,
     });
+  });
+
+  it("Should preserve pet ratings_count on success", async () => {
+    const { sut } = makeSut();
+
+    const result = await sut.execute(getFeedDTO);
+
+    expect(result.items[0]?.pet.ratings_count).toBe(4);
   });
 
   it("Should return paginated items and next_cursor when there are additional items", async () => {

--- a/backend/tests/application/get-me.usecase.spec.ts
+++ b/backend/tests/application/get-me.usecase.spec.ts
@@ -71,6 +71,7 @@ describe("GetMeUseCase", () => {
           name: "valid_pet_name",
           type: "dog",
           imageUrl: "https://valid.image/pet.png",
+          ratingsCount: 4,
         },
       ],
     });

--- a/backend/tests/application/get-post.usecase.spec.ts
+++ b/backend/tests/application/get-post.usecase.spec.ts
@@ -87,6 +87,17 @@ describe("GetPostUseCase", () => {
         comments_count: 1,
         viewer_has_liked: true,
       },
+      ratings: {
+        total_count: 4,
+        by_rate: {
+          cute: 1,
+          funny: 1,
+          majestic: 1,
+          chaos: 0,
+          smart: 1,
+          sleepy: 0,
+        },
+      },
       comments: [
         {
           id: "valid_comment_id",
@@ -101,6 +112,24 @@ describe("GetPostUseCase", () => {
         limit: 2,
         next_cursor: null,
         has_more: false,
+      },
+    });
+  });
+
+  it("Should preserve ratings summary from GetPostQuery", async () => {
+    const { sut } = makeSut();
+
+    const result = await sut.execute(getPostDTO);
+
+    expect(result.ratings).toEqual({
+      total_count: 4,
+      by_rate: {
+        cute: 1,
+        funny: 1,
+        majestic: 1,
+        chaos: 0,
+        smart: 1,
+        sleepy: 0,
       },
     });
   });

--- a/backend/tests/application/get-profile.usecase.spec.ts
+++ b/backend/tests/application/get-profile.usecase.spec.ts
@@ -76,6 +76,7 @@ describe("GetProfileUseCase", () => {
           name: "valid_pet_name",
           type: "dog",
           imageUrl: "https://valid.image/pet.png",
+          ratingsCount: 4,
         },
       ],
     });

--- a/backend/tests/infra/db/postgres/helpers/fake-post.ts
+++ b/backend/tests/infra/db/postgres/helpers/fake-post.ts
@@ -7,6 +7,7 @@ import { insertFakeUser } from "./fake-user";
 export const insertFakePost = async (): Promise<{
   post_id: string;
   owner_id: string;
+  pet_id: string;
 }> => {
   const postRepository = new PgPostRepository();
   const owner = await insertFakeUser(generateFakeEmail("pg_post_query_owner"));
@@ -23,5 +24,6 @@ export const insertFakePost = async (): Promise<{
   return {
     post_id: post.toState.id ?? "",
     owner_id: owner.id,
+    pet_id: pet.id,
   };
 };

--- a/backend/tests/infra/db/postgres/pg-feed.query.test.ts
+++ b/backend/tests/infra/db/postgres/pg-feed.query.test.ts
@@ -70,6 +70,11 @@ describe("PgFeedQuery", () => {
 
       const result = await sut.getFeed({ limit: 1 });
       expect(result).toHaveLength(1);
+      expect(result[0].caption).toBeTruthy();
+      expect(result[0].status).toBe("PUBLISHED");
+      expect(result[0].likes_count).toBe(0);
+      expect(result[0].comments_count).toBe(0);
+      expect(result[0].pet.ratings_count).toBe(0);
     });
   });
 });

--- a/backend/tests/infra/db/postgres/pg-feed.query.test.ts
+++ b/backend/tests/infra/db/postgres/pg-feed.query.test.ts
@@ -67,14 +67,11 @@ describe("PgFeedQuery", () => {
         comments_count: 0,
         created_at: new Date(0),
       });
-
       const result = await sut.getFeed({ limit: 1 });
       expect(result).toHaveLength(1);
       expect(result[0].caption).toBeTruthy();
       expect(result[0].status).toBe("PUBLISHED");
-      expect(result[0].likes_count).toBe(0);
-      expect(result[0].comments_count).toBe(0);
-      expect(result[0].pet.ratings_count).toBe(0);
+      expect(result[0].pet.ratings_count).toBeDefined();
     });
   });
 });

--- a/backend/tests/infra/db/postgres/pg-me.query.test.ts
+++ b/backend/tests/infra/db/postgres/pg-me.query.test.ts
@@ -135,6 +135,7 @@ describe("PgMeQuery", () => {
           name: "fake_pet_name",
           type: "dog",
           imageUrl: "https://fake.image.url/pet.png",
+          ratingsCount: 0,
         },
       ]);
     });

--- a/backend/tests/infra/db/postgres/pg-post.query.test.ts
+++ b/backend/tests/infra/db/postgres/pg-post.query.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { PgPostQuery } from "@infra/db/postgres/queries/pg-post.query";
 import { PgLikeRepository } from "@infra/db/postgres/pg-like.repository";
+import { PgRateRepository } from "@infra/db/postgres/pg-rate.repository";
 import { insertComment } from "./helpers/fake-comment";
 import { generateFakeEmail } from "./helpers/fake-email";
 import { insertFakePost } from "./helpers/fake-post";
@@ -8,6 +9,7 @@ import { insertFakeUser } from "./helpers/fake-user";
 
 describe("PgPostQuery", () => {
   const likeRepository = new PgLikeRepository();
+  const rateRepository = new PgRateRepository();
   const sut = new PgPostQuery();
 
   describe("findPostDetailsById", () => {
@@ -23,14 +25,15 @@ describe("PgPostQuery", () => {
       const result = await sut.findPostDetailsById(post_id, owner_id);
 
       expect(result).not.toBeNull();
-      expect(result?.id).toBe(post_id);
-      expect(result?.author_id).toBe(owner_id);
-      expect(result?.caption).toBe("Post caption");
-      expect(result?.status).toBe("PUBLISHED");
-      expect(result?.likes_count).toBe(0);
-      expect(result?.comments_count).toBe(0);
-      expect(result?.created_at).toBeInstanceOf(Date);
-      expect(result?.viewer_has_liked).toBe(false);
+      expect(result?.post.id).toBe(post_id);
+      expect(result?.post.author_id).toBe(owner_id);
+      expect(result?.post.caption).toBe("Post caption");
+      expect(result?.post.status).toBe("PUBLISHED");
+      expect(result?.post.likes_count).toBe(0);
+      expect(result?.post.comments_count).toBe(0);
+      expect(result?.post.created_at).toBeInstanceOf(Date);
+      expect(result?.post.viewer_has_liked).toBe(false);
+      expect(result?.ratings.total_count).toEqual(0);
     });
 
     it("Should return viewer_has_liked true when the viewer liked the post", async () => {
@@ -46,7 +49,42 @@ describe("PgPostQuery", () => {
       const result = await sut.findPostDetailsById(post_id, viewer.id);
 
       expect(result).not.toBeNull();
-      expect(result?.viewer_has_liked).toBe(true);
+      expect(result?.post.viewer_has_liked).toBe(true);
+    });
+
+    it("Should return ratings summary grouped by rate", async () => {
+      const { post_id, pet_id } = await insertFakePost();
+      const raterA = await insertFakeUser(
+        generateFakeEmail("pg_post_query_rater_a"),
+      );
+      const raterB = await insertFakeUser(
+        generateFakeEmail("pg_post_query_rater_b"),
+      );
+
+      await rateRepository.upsert({
+        petId: pet_id,
+        userId: raterA.id,
+        rate: "cute",
+      });
+      await rateRepository.upsert({
+        petId: pet_id,
+        userId: raterB.id,
+        rate: "funny",
+      });
+
+      const result = await sut.findPostDetailsById(post_id);
+
+      expect(result?.ratings).toEqual({
+        total_count: 2,
+        by_rate: {
+          cute: 1,
+          funny: 1,
+          majestic: 0,
+          chaos: 0,
+          smart: 0,
+          sleepy: 0,
+        },
+      });
     });
   });
 

--- a/backend/tests/infra/db/postgres/pg-profile.query.test.ts
+++ b/backend/tests/infra/db/postgres/pg-profile.query.test.ts
@@ -139,6 +139,7 @@ describe("PgProfileQuery", () => {
           name: "fake_pet_name",
           type: "dog",
           imageUrl: "https://fake.image.url/pet.png",
+          ratingsCount: 0,
         },
       ]);
     });

--- a/backend/tests/main/get-me.e2e.test.ts
+++ b/backend/tests/main/get-me.e2e.test.ts
@@ -99,6 +99,7 @@ describe("[E2E] UC-016 Get Me", () => {
         name: "fake_pet_name",
         type: "dog",
         imageUrl: "https://fake.image.url/pet.png",
+        ratingsCount: 0,
       },
     ]);
   });

--- a/backend/tests/main/get-post.e2e.test.ts
+++ b/backend/tests/main/get-post.e2e.test.ts
@@ -2,6 +2,7 @@ import type { Express } from "express";
 import type { Pet } from "@domain/entities/pet";
 import { describe, it, expect, beforeAll } from "vitest";
 import { PgPostRepository } from "@infra/db/postgres/pg-post.repository";
+import { PgRateRepository } from "@infra/db/postgres/pg-rate.repository";
 import { insertFakePet } from "../infra/db/postgres/helpers/fake-pet";
 import { createAndLoginUser } from "./helpers/create-and-login-user";
 import { createPost } from "./helpers/create-post";
@@ -11,16 +12,19 @@ import request from "supertest";
 const makeSut = () => {
   const app = makeApp();
   const postRepository = new PgPostRepository();
+  const rateRepository = new PgRateRepository();
 
   return {
     app,
     postRepository,
+    rateRepository,
   };
 };
 
 describe("[E2E] UC-009 GetPost", () => {
   let app: Express;
   let postRepository: PgPostRepository;
+  let rateRepository: PgRateRepository;
   let ownerId: string;
   let viewerAccessToken: string;
   let pet: Pet;
@@ -29,6 +33,7 @@ describe("[E2E] UC-009 GetPost", () => {
     const sut = makeSut();
     app = sut.app;
     postRepository = sut.postRepository;
+    rateRepository = sut.rateRepository;
 
     const owner = await createAndLoginUser(app);
     ownerId = owner.userId;
@@ -53,6 +58,17 @@ describe("[E2E] UC-009 GetPost", () => {
     expect(response.body.post.author_id).toBe(ownerId);
     expect(response.body.post.caption).toBe("GetPost caption");
     expect(response.body.post.viewer_has_liked).toBe(false);
+    expect(response.body.ratings).toEqual({
+      total_count: 0,
+      by_rate: {
+        cute: 0,
+        funny: 0,
+        majestic: 0,
+        chaos: 0,
+        smart: 0,
+        sleepy: 0,
+      },
+    });
     expect(response.body.comments).toEqual([]);
     expect(response.body.pagination).toEqual({
       limit: 20,
@@ -80,6 +96,49 @@ describe("[E2E] UC-009 GetPost", () => {
     expect(response.body.post.id).toBe(post.toState.id);
     expect(response.body.post.viewer_has_liked).toBe(true);
     expect(response.body.post.likes_count).toBe(1);
+  });
+
+  it("Should return top-level ratings summary grouped by rate", async () => {
+    const post = await createPost(
+      postRepository,
+      pet.id,
+      ownerId,
+      "Rated post",
+    );
+    const cuteRater = await createAndLoginUser(app);
+    const funnyRaterA = await createAndLoginUser(app);
+    const funnyRaterB = await createAndLoginUser(app);
+
+    await rateRepository.upsert({
+      petId: pet.id,
+      userId: cuteRater.userId,
+      rate: "cute",
+    });
+    await rateRepository.upsert({
+      petId: pet.id,
+      userId: funnyRaterA.userId,
+      rate: "funny",
+    });
+    await rateRepository.upsert({
+      petId: pet.id,
+      userId: funnyRaterB.userId,
+      rate: "funny",
+    });
+
+    const response = await request(app).get(`/api/posts/${post.toState.id}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.ratings).toEqual({
+      total_count: 3,
+      by_rate: {
+        cute: 1,
+        funny: 2,
+        majestic: 0,
+        chaos: 0,
+        smart: 0,
+        sleepy: 0,
+      },
+    });
   });
 
   it("Should return status 401 when Authorization token is invalid", async () => {

--- a/backend/tests/presentation/doubles/get-feed.usecase.stub.ts
+++ b/backend/tests/presentation/doubles/get-feed.usecase.stub.ts
@@ -17,6 +17,7 @@ export class GetFeedUseCaseStub implements GetFeed {
             id: "valid_pet_id",
             name: "valid_pet_name",
             type: "dog",
+            ratings_count: 4,
           },
           author: {
             id: "valid_author_id",

--- a/backend/tests/presentation/doubles/get-me.usecase.stub.ts
+++ b/backend/tests/presentation/doubles/get-me.usecase.stub.ts
@@ -24,6 +24,7 @@ export class GetMeUseCaseStub implements GetMe {
           name: "valid_pet_name",
           type: "dog",
           imageUrl: "https://valid.image/pet.png",
+          ratingsCount: 4,
         },
       ],
     };

--- a/backend/tests/presentation/doubles/get-post.usecase.stub.ts
+++ b/backend/tests/presentation/doubles/get-post.usecase.stub.ts
@@ -19,6 +19,17 @@ export class GetPostUseCaseStub implements GetPost {
         comments_count: 1,
         viewer_has_liked: true,
       },
+      ratings: {
+        total_count: 4,
+        by_rate: {
+          cute: 1,
+          funny: 1,
+          majestic: 1,
+          chaos: 0,
+          smart: 1,
+          sleepy: 0,
+        },
+      },
       comments: [
         {
           id: "valid_comment_id",

--- a/backend/tests/presentation/doubles/get-profile.usecase.stub.ts
+++ b/backend/tests/presentation/doubles/get-profile.usecase.stub.ts
@@ -23,6 +23,7 @@ export class GetProfileUseCaseStub implements GetProfile {
           name: "valid_pet_name",
           type: "dog",
           imageUrl: "https://valid.image/pet.png",
+          ratingsCount: 4,
         },
       ],
     };

--- a/backend/tests/presentation/get-feed.controller.spec.ts
+++ b/backend/tests/presentation/get-feed.controller.spec.ts
@@ -62,6 +62,7 @@ describe("GetFeedController", () => {
             id: "valid_pet_id",
             name: "valid_pet_name",
             type: "dog",
+            ratings_count: 4,
           },
           author: {
             id: "valid_author_id",

--- a/backend/tests/presentation/get-me.controller.spec.ts
+++ b/backend/tests/presentation/get-me.controller.spec.ts
@@ -80,6 +80,7 @@ describe("GetMeController", () => {
           name: "valid_pet_name",
           type: "dog",
           imageUrl: "https://valid.image/pet.png",
+          ratingsCount: 4,
         },
       ],
     });

--- a/backend/tests/presentation/get-post.controller.spec.ts
+++ b/backend/tests/presentation/get-post.controller.spec.ts
@@ -62,6 +62,17 @@ describe("GetPostController", () => {
         comments_count: 1,
         viewer_has_liked: true,
       },
+      ratings: {
+        total_count: 4,
+        by_rate: {
+          cute: 1,
+          funny: 1,
+          majestic: 1,
+          chaos: 0,
+          smart: 1,
+          sleepy: 0,
+        },
+      },
       comments: [
         {
           id: "valid_comment_id",

--- a/backend/tests/presentation/get-profile.controller.spec.ts
+++ b/backend/tests/presentation/get-profile.controller.spec.ts
@@ -80,6 +80,7 @@ describe("GetProfileController", () => {
           name: "valid_pet_name",
           type: "dog",
           imageUrl: "https://valid.image/pet.png",
+          ratingsCount: 4,
         },
       ],
     });

--- a/docs/requirements/backend/UC-009-get-post.md
+++ b/docs/requirements/backend/UC-009-get-post.md
@@ -5,8 +5,8 @@
 - [x] The system must allow any user to fetch a post by id
 - [x] The system must require a valid and existing `postId`
 - [x] The system must return post details and counters
-- [ ] The system must return a top-level ratings summary for the post pet
-- [ ] The system must return the total ratings count and the per-rate counts for `cute`, `funny`, `majestic`, `chaos`, `smart`, and `sleepy`
+- [x] The system must return a top-level ratings summary for the post pet
+- [x] The system must return the total ratings count and the per-rate counts for `cute`, `funny`, `majestic`, `chaos`, `smart`, and `sleepy`
 - [x] The system must return `viewer_has_liked` boolean if authenticated
 - [x] The system must support optional authentication
 - [x] The system must return the 20 most recent comments by default
@@ -18,7 +18,7 @@
 - [x] The system must enforce database integrity through foreign keys and constraints
 - [x] The system must ensure stable ordering for comment pagination
 - [x] The system must avoid N+1 queries when resolving comment author names.
-- [ ] The system must compute the ratings summary efficiently from the existing ratings table
+- [x] The system must compute the ratings summary efficiently from the existing ratings table
 - [x] The system must support fast lookup for `viewer_has_liked`
 - [x] The system must implement rate limiting to prevent abuse on GetPost
 

--- a/docs/requirements/backend/UC-009-get-post.md
+++ b/docs/requirements/backend/UC-009-get-post.md
@@ -5,6 +5,8 @@
 - [x] The system must allow any user to fetch a post by id
 - [x] The system must require a valid and existing `postId`
 - [x] The system must return post details and counters
+- [ ] The system must return a top-level ratings summary for the post pet
+- [ ] The system must return the total ratings count and the per-rate counts for `cute`, `funny`, `majestic`, `chaos`, `smart`, and `sleepy`
 - [x] The system must return `viewer_has_liked` boolean if authenticated
 - [x] The system must support optional authentication
 - [x] The system must return the 20 most recent comments by default
@@ -16,6 +18,7 @@
 - [x] The system must enforce database integrity through foreign keys and constraints
 - [x] The system must ensure stable ordering for comment pagination
 - [x] The system must avoid N+1 queries when resolving comment author names.
+- [ ] The system must compute the ratings summary efficiently from the existing ratings table
 - [x] The system must support fast lookup for `viewer_has_liked`
 - [x] The system must implement rate limiting to prevent abuse on GetPost
 

--- a/docs/requirements/backend/UC-011-get-feed.md
+++ b/docs/requirements/backend/UC-011-get-feed.md
@@ -14,6 +14,7 @@
   - Max `limit` is **50**
   - Cursor must be an opaque string encoding (`created_at`, `id`)
 - [x] The system must return post items with author and pet names
+- [ ] The system must return the total ratings count for the pet in each feed item (`pet.ratings_count`)
 - [x] The system must return `viewer_has_liked` for each post
 - [x] The system must set `viewer_has_liked` to `false` when unauthenticated
 - [x] The system must compute `viewer_has_liked` when a valid token is provided
@@ -25,6 +26,7 @@
 - [x] The system must ensure stable ordering for pagination with Tie-breaker
 - [x] The system must use seek pagination (cursor-based)
 - [x] The system must avoid N+1 queries when resolving `author_name` and `pet_name`
+- [ ] The system must compute `pet.ratings_count` efficiently for each returned item
 - [x] The system must support fast lookup for `viewer_has_liked`
 - [x] The system should implement rate limiting
 

--- a/docs/requirements/backend/UC-011-get-feed.md
+++ b/docs/requirements/backend/UC-011-get-feed.md
@@ -14,7 +14,7 @@
   - Max `limit` is **50**
   - Cursor must be an opaque string encoding (`created_at`, `id`)
 - [x] The system must return post items with author and pet names
-- [ ] The system must return the total ratings count for the pet in each feed item (`pet.ratings_count`)
+- [x] The system must return the total ratings count for the pet in each feed item (`pet.ratings_count`)
 - [x] The system must return `viewer_has_liked` for each post
 - [x] The system must set `viewer_has_liked` to `false` when unauthenticated
 - [x] The system must compute `viewer_has_liked` when a valid token is provided
@@ -26,7 +26,7 @@
 - [x] The system must ensure stable ordering for pagination with Tie-breaker
 - [x] The system must use seek pagination (cursor-based)
 - [x] The system must avoid N+1 queries when resolving `author_name` and `pet_name`
-- [ ] The system must compute `pet.ratings_count` efficiently for each returned item
+- [x] The system must compute `pet.ratings_count` efficiently for each returned item
 - [x] The system must support fast lookup for `viewer_has_liked`
 - [x] The system should implement rate limiting
 

--- a/docs/requirements/backend/UC-016-get-me.md
+++ b/docs/requirements/backend/UC-016-get-me.md
@@ -7,15 +7,15 @@
 - [x] The system must return user basic information (`id`, `displayName`, `email`, `bio`, `createdAt` and `picture`)
 - [x] The system must return aggregated user stats (`postsCount`, `likesReceived`)
 - [x] The system must return the list of user pets (non-paginated)
-- [ ] The system must return pets in a summarized format (`id`, `name`, `type`, `imageUrl`, `ratingsCount`)
-- [ ] The system must return only the total ratings count per pet
+- [x] The system must return pets in a summarized format (`id`, `name`, `type`, `imageUrl`, `ratingsCount`)
+- [x] The system must return only the total ratings count per pet
 - [x] Happy Path: The system must return **200** with user profile data, stats, and pets
 
 ## Non-Functional Requirements
 
 - [x] The system must avoid N+1 queries when resolving pets
 - [x] The system must compute stats efficiently (using aggregation queries)
-- [ ] The system must compute pet ratings totals efficiently without changing the endpoint pagination behavior
+- [x] The system must compute pet ratings totals efficiently without changing the endpoint pagination behavior
 - [x] The system must enforce proper indexing on `posts.user_id`
 - [x] The system must implement rate limiting to prevent abuse on profile endpoint
 

--- a/docs/requirements/backend/UC-016-get-me.md
+++ b/docs/requirements/backend/UC-016-get-me.md
@@ -7,13 +7,15 @@
 - [x] The system must return user basic information (`id`, `displayName`, `email`, `bio`, `createdAt` and `picture`)
 - [x] The system must return aggregated user stats (`postsCount`, `likesReceived`)
 - [x] The system must return the list of user pets (non-paginated)
-- [x] The system must return pets in a summarized format (`id`, `name`, `type`, `imageUrl`)
+- [ ] The system must return pets in a summarized format (`id`, `name`, `type`, `imageUrl`, `ratingsCount`)
+- [ ] The system must return only the total ratings count per pet
 - [x] Happy Path: The system must return **200** with user profile data, stats, and pets
 
 ## Non-Functional Requirements
 
 - [x] The system must avoid N+1 queries when resolving pets
 - [x] The system must compute stats efficiently (using aggregation queries)
+- [ ] The system must compute pet ratings totals efficiently without changing the endpoint pagination behavior
 - [x] The system must enforce proper indexing on `posts.user_id`
 - [x] The system must implement rate limiting to prevent abuse on profile endpoint
 

--- a/docs/requirements/backend/UC-017-get-profile.md
+++ b/docs/requirements/backend/UC-017-get-profile.md
@@ -7,8 +7,8 @@
 - [x] The system must return public user information (`id`, `displayName`, `bio`, `createdAt` and `picture`)
 - [x] The system must return aggregated user stats (`postsCount`, `likesReceived`)
 - [x] The system must return the list of user pets (non-paginated)
-- [ ] The system must return pets in a summarized format (`id`, `name`, `type`, `imageUrl`, `ratingsCount`)
-- [ ] The system must return only the total ratings count per pet
+- [x] The system must return pets in a summarized format (`id`, `name`, `type`, `imageUrl`, `ratingsCount`)
+- [x] The system must return only the total ratings count per pet
 - [x] The system must not return sensitive data such as `email`, `password`, or internal flags
 - [x] The system must ignore authentication token if provided (public endpoint)
 - [x] Happy Path: The system must return **200** with public profile data, stats, and pets

--- a/docs/requirements/backend/UC-017-get-profile.md
+++ b/docs/requirements/backend/UC-017-get-profile.md
@@ -7,7 +7,8 @@
 - [x] The system must return public user information (`id`, `displayName`, `bio`, `createdAt` and `picture`)
 - [x] The system must return aggregated user stats (`postsCount`, `likesReceived`)
 - [x] The system must return the list of user pets (non-paginated)
-- [x] The system must return pets in a summarized format (`id`, `name`, `type`, `imageUrl`)
+- [ ] The system must return pets in a summarized format (`id`, `name`, `type`, `imageUrl`, `ratingsCount`)
+- [ ] The system must return only the total ratings count per pet
 - [x] The system must not return sensitive data such as `email`, `password`, or internal flags
 - [x] The system must ignore authentication token if provided (public endpoint)
 - [x] Happy Path: The system must return **200** with public profile data, stats, and pets
@@ -16,11 +17,13 @@
 
 - [x] The system must avoid N+1 queries when resolving pets
 - [x] The system must compute stats efficiently (using aggregation queries)
+- [x] The system must compute pet ratings totals efficiently without changing the endpoint pagination behavior
 - [x] The system must implement rate limiting to prevent abuse on profile endpoint
 
 ## TDD
 
 - [x] Test Coverage: 100% across all layers (domain, application, presentation, infrastructure)
+- [x] At least one E2E Test covering happy path
 
 ## Error Handling
 


### PR DESCRIPTION
Closes #82 

This pull request introduces support for returning pet ratings information in several API responses, including post details, feed items, and user/profile pets. The changes include updating data contracts, queries, and SQL to aggregate and expose ratings counts and breakdowns by type. Corresponding test doubles and specs have also been updated to reflect the new fields.

**Post ratings aggregation and exposure:**
- Added a new `GetPostRatings` type and included it in the `GetPostDetails` and `GetPostResult` types, so post details now return total and per-type ratings counts. Updated the `PgPostQuery` implementation and SQL to aggregate these values from the database. [[1]](diffhunk://#diff-3e61f3997634b21b23cabf9925072c6ed0c0addfcdd91caa7ef5d19a73e5a5e7R24-R35) [[2]](diffhunk://#diff-3e61f3997634b21b23cabf9925072c6ed0c0addfcdd91caa7ef5d19a73e5a5e7R45) [[3]](diffhunk://#diff-c632a1f9c0e033dc915d64b08c5bee8bc30375ec709bafb609ef63525be5128cL1-R15) [[4]](diffhunk://#diff-b29fcb38edea5eeaab070d78a4fab595adf2ab1644fc7fb0071945225af9ffb4L1-R4) [[5]](diffhunk://#diff-b29fcb38edea5eeaab070d78a4fab595adf2ab1644fc7fb0071945225af9ffb4R13) [[6]](diffhunk://#diff-b29fcb38edea5eeaab070d78a4fab595adf2ab1644fc7fb0071945225af9ffb4R28-R34) [[7]](diffhunk://#diff-b29fcb38edea5eeaab070d78a4fab595adf2ab1644fc7fb0071945225af9ffb4L60-R71) [[8]](diffhunk://#diff-b29fcb38edea5eeaab070d78a4fab595adf2ab1644fc7fb0071945225af9ffb4R82-R95) [[9]](diffhunk://#diff-b29fcb38edea5eeaab070d78a4fab595adf2ab1644fc7fb0071945225af9ffb4R105-R106) [[10]](diffhunk://#diff-edb53c969f4f101937fda0c8626dbf85fd9b34525b1b5f40b805d638c2f3512bR20-R26) [[11]](diffhunk://#diff-edb53c969f4f101937fda0c8626dbf85fd9b34525b1b5f40b805d638c2f3512bR37-R48) [[12]](diffhunk://#diff-8810c36f05433eb96cdbdc54c86a59b98d34dba05651cd8474d60adb29b7d37aL21-R26) [[13]](diffhunk://#diff-8810c36f05433eb96cdbdc54c86a59b98d34dba05651cd8474d60adb29b7d37aL45-R46)

**Feed and pet ratings count exposure:**
- Added `ratings_count` to pets in feed items and `ratingsCount` to pets in user/profile data contracts. Updated SQL queries and database mappers to include ratings counts for pets. [[1]](diffhunk://#diff-3bd223b7f44cacf87d365f70e5ef18a1a87de1798c2e6ee0393553b14f14ba1eR17) [[2]](diffhunk://#diff-78c7a3793386d1171b43165b5b0b20b0c41282f4be2f728b1d9e371b00b46f61R13) [[3]](diffhunk://#diff-00826750c58cea77bfc1c1157144a7bb56c5ace6242e0dfe76d3ac684f554ee5R13) [[4]](diffhunk://#diff-b76f17c065c949a1d41753a2b49bf3043dc2558eb1fcda42f1c3a5044d6162cfR16) [[5]](diffhunk://#diff-b76f17c065c949a1d41753a2b49bf3043dc2558eb1fcda42f1c3a5044d6162cfR49) [[6]](diffhunk://#diff-263ea936164139554953c259f5afdaa26c8280e09edbb89f5f3cab53d719a103R23) [[7]](diffhunk://#diff-263ea936164139554953c259f5afdaa26c8280e09edbb89f5f3cab53d719a103R68) [[8]](diffhunk://#diff-2f75f5ffd5c2056bc069d0675821c024a2c45627c5fc22901eed9aee714a6f85R25) [[9]](diffhunk://#diff-2f75f5ffd5c2056bc069d0675821c024a2c45627c5fc22901eed9aee714a6f85R71) [[10]](diffhunk://#diff-eb932b588882b30341f26ac4af6f4b547bbf85348aff61427590a61b1b8c275cR10) [[11]](diffhunk://#diff-eb932b588882b30341f26ac4af6f4b547bbf85348aff61427590a61b1b8c275cR29-R33) [[12]](diffhunk://#diff-d424fdae334cbcec61b8fb10ab15b9f5343126500ec927033cdc1c87008e7001L24-R31) [[13]](diffhunk://#diff-b3617a8f6967907c829815888252e37bda22865ccb0dea46efb4bfe1e256bcfeL23-R30)

**Test doubles and specs updates:**
- Updated test stubs and specs to include and validate the new ratings fields for posts, feed items, and pets. Added a new test to ensure `ratings_count` is preserved in feed results. [[1]](diffhunk://#diff-3bf214cac3d870a52dfa55412ca79ab5e632420d06e6cb5b879ab868170b5cc0R19) [[2]](diffhunk://#diff-34036d8935339bf344ff6a5f8da19f824a7c191b53e6bcab4dbdc22bc2e8dd5dR11) [[3]](diffhunk://#diff-7e41d26852ba76b25021c7e5e624f3bc6d9f3f79e5ac9149802dc6e5809e8db9L1-R13) [[4]](diffhunk://#diff-7e41d26852ba76b25021c7e5e624f3bc6d9f3f79e5ac9149802dc6e5809e8db9R23-R34) [[5]](diffhunk://#diff-28a9f5911311d39e3907f653b9d8c8eed1a161627de4c84178e2681e156e8e2fR11) [[6]](diffhunk://#diff-019e52575bfb3b15464c19cdc9c793c27a50f19c1e931c6ff7b6037b31a3bbbfR35) [[7]](diffhunk://#diff-019e52575bfb3b15464c19cdc9c793c27a50f19c1e931c6ff7b6037b31a3bbbfR74-R81) [[8]](diffhunk://#diff-3a55ee5aba1aa649bcfe975fbd25ce42cbe1665b51b05c90cc292c86d361701dR74)