### PR TITLE
refactor(rate): add materialized view of total ratings count

### DIFF
--- a/backend/src/main/composition/pets/delete-rate.usecase.factory.ts
+++ b/backend/src/main/composition/pets/delete-rate.usecase.factory.ts
@@ -1,11 +1,18 @@
 import { DeleteRateUseCase } from "@application/usecases/delete-rate.usecase";
 import { PgPetRepository } from "@infra/db/postgres/pg-pet.repository";
 import { PgRateRepository } from "@infra/db/postgres/pg-rate.repository";
+import { PgUnitOfWorkAdapter } from "@infra/db/postgres/adapters/pg-unit-of-work.adapter";
 
 export const makeDeleteRateUseCase = () => {
   const petRepository = new PgPetRepository();
   const rateRepository = new PgRateRepository();
-  const usecase = new DeleteRateUseCase(petRepository, rateRepository);
+  const unitOfWork = new PgUnitOfWorkAdapter();
+  const usecase = new DeleteRateUseCase(
+    petRepository,
+    rateRepository,
+    petRepository,
+    unitOfWork,
+  );
 
   return usecase;
 };

--- a/backend/src/main/composition/pets/rate-pet.usecase.factory.ts
+++ b/backend/src/main/composition/pets/rate-pet.usecase.factory.ts
@@ -1,11 +1,18 @@
 import { RatePetUseCase } from "@application/usecases/rate-pet.usecase";
 import { PgPetRepository } from "@infra/db/postgres/pg-pet.repository";
 import { PgRateRepository } from "@infra/db/postgres/pg-rate.repository";
+import { PgUnitOfWorkAdapter } from "@infra/db/postgres/adapters/pg-unit-of-work.adapter";
 
 export const makeRatePetUseCase = () => {
   const petRepository = new PgPetRepository();
   const rateRepository = new PgRateRepository();
-  const usecase = new RatePetUseCase(petRepository, rateRepository);
+  const unitOfWork = new PgUnitOfWorkAdapter();
+  const usecase = new RatePetUseCase(
+    petRepository,
+    rateRepository,
+    petRepository,
+    unitOfWork,
+  );
 
   return usecase;
 };

--- a/backend/src/main/config/env.ts
+++ b/backend/src/main/config/env.ts
@@ -1,14 +1,15 @@
+type NodeEnv = "development" | "production";
+
 export const env = {
-  NODE_ENV: process.env.NODE_ENV || "development",
-  PORT: process.env.PORT || 8000,
+  NODE_ENV: (process.env.NODE_ENV as NodeEnv) || "development",
+  PORT: Number(process.env.PORT) || 8000,
   DATABASE_URL:
     process.env.DATABASE_URL ||
     "postgres://ratemypet:ratemypet@localhost:5432/ratemypet_dev?sslmode=disable",
   JWT_ACCESS_TOKEN_SECRET:
     process.env.JWT_ACCESS_TOKEN_SECRET || "dev_access_token_secret",
   JWT_ACCESS_TOKEN_TTL: process.env.JWT_ACCESS_TOKEN_TTL || "30s",
-  REFRESH_TOKEN_TTL:
-    (process.env.REFRESH_TOKEN_TTL as unknown as number) || 60_000,
+  REFRESH_TOKEN_TTL: Number(process.env.REFRESH_TOKEN_TTL) || 60_000,
   RATE_LIMIT_ENABLED: process.env.RATE_LIMIT_ENABLED || "true",
   GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID || "",
   GEMINI_API_KEY: process.env.GEMINI_API_KEY || "",
@@ -17,4 +18,4 @@ export const env = {
   AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY || "",
   AWS_BUCKET_NAME: process.env.AWS_BUCKET_NAME || "development-bucket",
   AWS_ENDPOINT: process.env.AWS_ENDPOINT || "https://my-s3-endpoint.com",
-};
+} as const;

--- a/backend/src/main/layers/application/repositories/delete-rate.repository.ts
+++ b/backend/src/main/layers/application/repositories/delete-rate.repository.ts
@@ -1,3 +1,9 @@
+import type { Transaction } from "@application/ports/unit-of-work.contract";
+
 export interface DeleteRateRepository {
-  deleteByPetIdAndUserId(petId: string, userId: string): Promise<boolean>;
+  deleteByPetIdAndUserId(
+    petId: string,
+    userId: string,
+    transaction?: Transaction,
+  ): Promise<boolean>;
 }

--- a/backend/src/main/layers/application/repositories/rate.repository.ts
+++ b/backend/src/main/layers/application/repositories/rate.repository.ts
@@ -1,11 +1,9 @@
 import type { Transaction } from "@application/ports/unit-of-work.contract";
 import type { Rate } from "@domain/entities/rate";
 
-export type UpsertOperation = "created" | "updated" | "unchanged";
-
 export type UpsertResult = {
   rate: Rate;
-  operation: UpsertOperation;
+  wasCreated: boolean;
 };
 
 export interface RateRepository {

--- a/backend/src/main/layers/application/repositories/rate.repository.ts
+++ b/backend/src/main/layers/application/repositories/rate.repository.ts
@@ -1,6 +1,14 @@
+import type { Transaction } from "@application/ports/unit-of-work.contract";
 import type { Rate } from "@domain/entities/rate";
+
+export type UpsertOperation = "created" | "updated" | "unchanged";
+
+export type UpsertResult = {
+  rate: Rate;
+  operation: UpsertOperation;
+};
 
 export interface RateRepository {
   findByPetIdAndUserId(petId: string, userId: string): Promise<Rate | null>;
-  upsert(rate: Rate): Promise<Rate>;
+  upsert(rate: Rate, transaction?: Transaction): Promise<UpsertResult>;
 }

--- a/backend/src/main/layers/application/repositories/update-pet-ratings-count.repository.ts
+++ b/backend/src/main/layers/application/repositories/update-pet-ratings-count.repository.ts
@@ -5,4 +5,8 @@ export interface UpdatePetRatingsCountRepository {
     petId: string,
     transaction?: Transaction,
   ): Promise<void>;
+  decrementRatingsCount(
+    petId: string,
+    transaction?: Transaction,
+  ): Promise<void>;
 }

--- a/backend/src/main/layers/application/repositories/update-pet-ratings-count.repository.ts
+++ b/backend/src/main/layers/application/repositories/update-pet-ratings-count.repository.ts
@@ -1,0 +1,8 @@
+import type { Transaction } from "@application/ports/unit-of-work.contract";
+
+export interface UpdatePetRatingsCountRepository {
+  incrementRatingsCount(
+    petId: string,
+    transaction?: Transaction,
+  ): Promise<void>;
+}

--- a/backend/src/main/layers/application/usecases/delete-rate.usecase.ts
+++ b/backend/src/main/layers/application/usecases/delete-rate.usecase.ts
@@ -1,6 +1,8 @@
 import { AppError } from "@application/errors/app-error";
 import type { DeleteRateRepository } from "@application/repositories/delete-rate.repository";
 import type { FindPetRepository } from "@application/repositories/find-pet.repository";
+import type { UpdatePetRatingsCountRepository } from "@application/repositories/update-pet-ratings-count.repository";
+import type { UnitOfWork } from "@application/ports/unit-of-work.contract";
 import type {
   DeleteRate,
   DeleteRateDTO,
@@ -11,6 +13,8 @@ export class DeleteRateUseCase implements DeleteRate {
   constructor(
     private readonly findPetRepository: FindPetRepository,
     private readonly deleteRateRepository: DeleteRateRepository,
+    private readonly updatePetRatingsCountRepository: UpdatePetRatingsCountRepository,
+    private readonly unitOfWork: UnitOfWork,
   ) {}
 
   async execute(data: DeleteRateDTO): Promise<DeleteRateResult> {
@@ -20,14 +24,29 @@ export class DeleteRateUseCase implements DeleteRate {
       throw new AppError("NOT_FOUND", "The specified pet does not exist.");
     }
 
-    const wasDeleted = await this.deleteRateRepository.deleteByPetIdAndUserId(
-      data.petId,
-      data.userId,
-    );
+    return await this.unitOfWork.execute(async (transactionClient) => {
+      const wasDeleted = await this.deleteRateRepository.deleteByPetIdAndUserId(
+        data.petId,
+        data.userId,
+        transactionClient,
+      );
 
-    return {
-      petId: data.petId,
-      status: wasDeleted ? "deleted" : "unchanged",
-    };
+      if (!wasDeleted) {
+        return {
+          petId: data.petId,
+          status: "unchanged",
+        };
+      }
+
+      await this.updatePetRatingsCountRepository.decrementRatingsCount(
+        data.petId,
+        transactionClient,
+      );
+
+      return {
+        petId: data.petId,
+        status: "deleted",
+      };
+    });
   }
 }

--- a/backend/src/main/layers/application/usecases/rate-pet.usecase.ts
+++ b/backend/src/main/layers/application/usecases/rate-pet.usecase.ts
@@ -1,5 +1,7 @@
 import type { FindPetRepository } from "@application/repositories/find-pet.repository";
 import type { RateRepository } from "@application/repositories/rate.repository";
+import type { UpdatePetRatingsCountRepository } from "@application/repositories/update-pet-ratings-count.repository";
+import type { UnitOfWork } from "@application/ports/unit-of-work.contract";
 import { AppError } from "@application/errors/app-error";
 import type {
   RatePet,
@@ -11,6 +13,8 @@ export class RatePetUseCase implements RatePet {
   constructor(
     private readonly findPetRepository: FindPetRepository,
     private readonly rateRepository: RateRepository,
+    private readonly updatePetRatingsCountRepository: UpdatePetRatingsCountRepository,
+    private readonly unitOfWork: UnitOfWork,
   ) {}
 
   async execute(data: RatePetDTO): Promise<RatePetResult> {
@@ -20,11 +24,23 @@ export class RatePetUseCase implements RatePet {
       throw new AppError("NOT_FOUND", "The specified pet does not exist.");
     }
 
-    const updatedRate = await this.rateRepository.upsert(data);
+    return await this.unitOfWork.execute(async (transactionClient) => {
+      const upsertResult = await this.rateRepository.upsert(
+        data,
+        transactionClient,
+      );
 
-    return {
-      petId: updatedRate.petId,
-      rate: updatedRate.rate,
-    };
+      if (upsertResult.operation === "created") {
+        await this.updatePetRatingsCountRepository.incrementRatingsCount(
+          data.petId,
+          transactionClient,
+        );
+      }
+
+      return {
+        petId: upsertResult.rate.petId,
+        rate: upsertResult.rate.rate,
+      };
+    });
   }
 }

--- a/backend/src/main/layers/application/usecases/rate-pet.usecase.ts
+++ b/backend/src/main/layers/application/usecases/rate-pet.usecase.ts
@@ -30,7 +30,7 @@ export class RatePetUseCase implements RatePet {
         transactionClient,
       );
 
-      if (upsertResult.operation === "created") {
+      if (upsertResult.wasCreated) {
         await this.updatePetRatingsCountRepository.incrementRatingsCount(
           data.petId,
           transactionClient,

--- a/backend/src/main/layers/infra/db/migrations/20260401100000_add_ratings_count_to_pets_table.sql
+++ b/backend/src/main/layers/infra/db/migrations/20260401100000_add_ratings_count_to_pets_table.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+ALTER TABLE pets
+ADD COLUMN ratings_count INTEGER NOT NULL DEFAULT 0;
+
+-- migrate:down
+ALTER TABLE pets
+DROP COLUMN IF EXISTS ratings_count;

--- a/backend/src/main/layers/infra/db/postgres/pg-pet.repository.ts
+++ b/backend/src/main/layers/infra/db/postgres/pg-pet.repository.ts
@@ -77,4 +77,12 @@ export class PgPetRepository
     const client = (transaction ? transaction : this.pool) as typeof this.pool;
     await client.query(sql.INCREMENT_RATINGS_COUNT, [petId]);
   }
+
+  async decrementRatingsCount(
+    petId: string,
+    transaction?: Transaction,
+  ): Promise<void> {
+    const client = (transaction ? transaction : this.pool) as typeof this.pool;
+    await client.query(sql.DECREMENT_RATINGS_COUNT, [petId]);
+  }
 }

--- a/backend/src/main/layers/infra/db/postgres/pg-pet.repository.ts
+++ b/backend/src/main/layers/infra/db/postgres/pg-pet.repository.ts
@@ -3,6 +3,7 @@ import type { UploadPetRepository } from "@application/repositories/upload-pet.r
 import type { FindPetRepository } from "@application/repositories/find-pet.repository";
 import type { FindPetWithDeletedRepository } from "@application/repositories/find-pet-with-deleted.repository";
 import type { DeletePetRepository } from "@application/repositories/delete-pet.repository";
+import type { UpdatePetRatingsCountRepository } from "@application/repositories/update-pet-ratings-count.repository";
 import type { Transaction } from "@application/ports/unit-of-work.contract";
 import { PgPool } from "./helpers/pg-pool";
 import { sql } from "./sql/pet.sql";
@@ -12,7 +13,8 @@ export class PgPetRepository
     UploadPetRepository,
     FindPetRepository,
     FindPetWithDeletedRepository,
-    DeletePetRepository
+    DeletePetRepository,
+    UpdatePetRatingsCountRepository
 {
   private readonly pool: PgPool;
   constructor() {
@@ -66,5 +68,13 @@ export class PgPetRepository
   ): Promise<void> {
     const client = (transaction ? transaction : this.pool) as typeof this.pool;
     await client.query(sql.SOFT_DELETE_PET, [petId]);
+  }
+
+  async incrementRatingsCount(
+    petId: string,
+    transaction?: Transaction,
+  ): Promise<void> {
+    const client = (transaction ? transaction : this.pool) as typeof this.pool;
+    await client.query(sql.INCREMENT_RATINGS_COUNT, [petId]);
   }
 }

--- a/backend/src/main/layers/infra/db/postgres/pg-rate.repository.ts
+++ b/backend/src/main/layers/infra/db/postgres/pg-rate.repository.ts
@@ -1,9 +1,17 @@
 import type { DeleteRateRepository } from "@application/repositories/delete-rate.repository";
-import type { RateRepository } from "@application/repositories/rate.repository";
+import type {
+  RateRepository,
+  UpsertResult,
+} from "@application/repositories/rate.repository";
+import type { Transaction } from "@application/ports/unit-of-work.contract";
 import type { Rate } from "@domain/entities/rate";
 import { toRate, type RateRow } from "@infra/mappers/rate-mapper";
 import { PgPool } from "./helpers/pg-pool";
 import { sql } from "./sql/rate.sql";
+
+type UpsertRateRow = RateRow & {
+  was_created: boolean;
+};
 
 export class PgRateRepository implements RateRepository, DeleteRateRepository {
   private readonly pool: PgPool;
@@ -25,13 +33,22 @@ export class PgRateRepository implements RateRepository, DeleteRateRepository {
     return rate;
   }
 
-  async upsert(rate: Rate): Promise<Rate> {
-    const rateRows = await this.pool.query<RateRow>(sql.UPSERT_RATE, [
+  async upsert(rate: Rate, transaction?: Transaction): Promise<UpsertResult> {
+    const client = (transaction ? transaction : this.pool) as PgPool;
+    const rateRows = await client.query<UpsertRateRow>(sql.UPSERT_RATE, [
       rate.petId,
       rate.userId,
       rate.rate,
     ]);
-    return toRate(rateRows.rows[0]);
+
+    const upsertedRate = rateRows.rows[0];
+    const wasCreated = upsertedRate.was_created;
+    const mappedRate = toRate(upsertedRate);
+
+    return {
+      rate: mappedRate,
+      wasCreated,
+    };
   }
 
   async deleteByPetIdAndUserId(

--- a/backend/src/main/layers/infra/db/postgres/pg-rate.repository.ts
+++ b/backend/src/main/layers/infra/db/postgres/pg-rate.repository.ts
@@ -54,8 +54,10 @@ export class PgRateRepository implements RateRepository, DeleteRateRepository {
   async deleteByPetIdAndUserId(
     petId: string,
     userId: string,
+    transaction?: Transaction,
   ): Promise<boolean> {
-    const result = await this.pool.query(sql.DELETE_RATE, [petId, userId]);
+    const client = (transaction ? transaction : this.pool) as PgPool;
+    const result = await client.query(sql.DELETE_RATE, [petId, userId]);
     return (result.rowCount ?? 0) > 0;
   }
 }

--- a/backend/src/main/layers/infra/db/postgres/sql/feed.query.sql.ts
+++ b/backend/src/main/layers/infra/db/postgres/sql/feed.query.sql.ts
@@ -7,7 +7,7 @@ export const sql = {
     pet.id AS pet_id,
     pet.name AS pet_name,
     pet.type AS pet_type,
-    COALESCE(ratings.ratings_count, 0)::int AS pet_ratings_count,
+    pet.ratings_count AS pet_ratings_count,
     u.id AS author_id,
     u.name AS author_name,
     p.likes_count,
@@ -26,11 +26,6 @@ export const sql = {
   FROM posts p
   INNER JOIN users u ON u.id = p.author_id
   INNER JOIN pets pet ON pet.id = p.pet_id
-  LEFT JOIN LATERAL (
-    SELECT COUNT(*)::int AS ratings_count
-    FROM ratings r
-    WHERE r.pet_id = pet.id
-  ) ratings ON TRUE
   WHERE p.status = 'PUBLISHED'
     AND (
       $1::timestamptz IS NULL

--- a/backend/src/main/layers/infra/db/postgres/sql/me.query.sql.ts
+++ b/backend/src/main/layers/infra/db/postgres/sql/me.query.sql.ts
@@ -22,13 +22,8 @@ export const sql = {
     name,
     type,
     image_url,
-    COALESCE(ratings.ratings_count, 0)::int AS ratings_count
+    ratings_count
   FROM pets
-  LEFT JOIN LATERAL (
-    SELECT COUNT(*)::int AS ratings_count
-    FROM ratings r
-    WHERE r.pet_id = pets.id
-  ) ratings ON TRUE
   WHERE owner_id = $1
     AND deleted_at IS NULL
   ORDER BY created_at ASC, id ASC

--- a/backend/src/main/layers/infra/db/postgres/sql/pet.sql.ts
+++ b/backend/src/main/layers/infra/db/postgres/sql/pet.sql.ts
@@ -27,4 +27,9 @@ export const sql = {
   WHERE id = $1
     AND deleted_at IS NULL
   `,
+  INCREMENT_RATINGS_COUNT: `
+  UPDATE pets
+  SET ratings_count = ratings_count + 1
+  WHERE id = $1
+  `,
 };

--- a/backend/src/main/layers/infra/db/postgres/sql/pet.sql.ts
+++ b/backend/src/main/layers/infra/db/postgres/sql/pet.sql.ts
@@ -32,4 +32,9 @@ export const sql = {
   SET ratings_count = ratings_count + 1
   WHERE id = $1
   `,
+  DECREMENT_RATINGS_COUNT: `
+  UPDATE pets
+  SET ratings_count = GREATEST(0, ratings_count - 1)
+  WHERE id = $1
+  `,
 };

--- a/backend/src/main/layers/infra/db/postgres/sql/post.query.sql.ts
+++ b/backend/src/main/layers/infra/db/postgres/sql/post.query.sql.ts
@@ -17,7 +17,7 @@ export const sql = {
     p.created_at,
     p.likes_count,
     p.comments_count,
-    COALESCE(ratings.total_count, 0)::int AS ratings_total_count,
+    pet.ratings_count AS ratings_total_count,
     COALESCE(ratings.cute_count, 0)::int AS cute_count,
     COALESCE(ratings.funny_count, 0)::int AS funny_count,
     COALESCE(ratings.majestic_count, 0)::int AS majestic_count,
@@ -34,9 +34,9 @@ export const sql = {
       )
     ) AS viewer_has_liked
   FROM posts p
+  INNER JOIN pets pet ON pet.id = p.pet_id
   LEFT JOIN LATERAL (
     SELECT
-      COUNT(*)::int AS total_count,
       COUNT(*) FILTER (WHERE r.rate = 'cute')::int AS cute_count,
       COUNT(*) FILTER (WHERE r.rate = 'funny')::int AS funny_count,
       COUNT(*) FILTER (WHERE r.rate = 'majestic')::int AS majestic_count,

--- a/backend/src/main/layers/infra/db/postgres/sql/profile.query.sql.ts
+++ b/backend/src/main/layers/infra/db/postgres/sql/profile.query.sql.ts
@@ -21,13 +21,8 @@ export const sql = {
     name,
     type,
     image_url,
-    COALESCE(ratings.ratings_count, 0)::int AS ratings_count
+    ratings_count
   FROM pets
-  LEFT JOIN LATERAL (
-    SELECT COUNT(*)::int AS ratings_count
-    FROM ratings r
-    WHERE r.pet_id = pets.id
-  ) ratings ON TRUE
   WHERE owner_id = $1
     AND deleted_at IS NULL
   ORDER BY created_at ASC, id ASC

--- a/backend/src/main/layers/infra/db/postgres/sql/rate.sql.ts
+++ b/backend/src/main/layers/infra/db/postgres/sql/rate.sql.ts
@@ -13,11 +13,17 @@ export const sql = {
   VALUES ($1, $2, $3)
   ON CONFLICT (pet_id, user_id)
   DO UPDATE SET
-    rate = EXCLUDED.rate,
-    updated_at = CASE
-      WHEN ratings.rate = EXCLUDED.rate THEN ratings.updated_at
-      ELSE NOW()
-    END
-  RETURNING pet_id, user_id, rate, created_at, updated_at
+  rate = EXCLUDED.rate,
+  updated_at = CASE
+    WHEN ratings.rate = EXCLUDED.rate THEN ratings.updated_at
+    ELSE NOW()
+  END
+  RETURNING
+  pet_id,
+  user_id,
+  rate,
+  created_at,
+  updated_at,
+  (xmax = 0) AS was_created
   `,
 };

--- a/backend/tests/application/delete-rate.usecase.spec.ts
+++ b/backend/tests/application/delete-rate.usecase.spec.ts
@@ -1,8 +1,11 @@
 import { AppError } from "@application/errors/app-error";
+import type { Transaction } from "@application/ports/unit-of-work.contract";
 import { DeleteRateUseCase } from "@application/usecases/delete-rate.usecase";
 import { describe, expect, it, vi } from "vitest";
 import { DeleteRateRepositoryStub } from "./doubles/delete-rate.repository.stub";
 import { FindPetRepositoryStub } from "./doubles/find-pet.repository.stub";
+import { UpdatePetRatingsCountRepositoryStub } from "./doubles/update-pet-ratings-count.repository.stub";
+import { UnitOfWorkStub } from "./doubles/unit-of-work.stub";
 
 describe("DeleteRateUseCase", () => {
   const makeSut = () => {
@@ -13,15 +16,27 @@ describe("DeleteRateUseCase", () => {
       deleteRateRepositoryStub,
       "deleteByPetIdAndUserId",
     );
+    const updatePetRatingsCountRepositoryStub =
+      new UpdatePetRatingsCountRepositoryStub();
+    const decrementRatingsCountSpy = vi.spyOn(
+      updatePetRatingsCountRepositoryStub,
+      "decrementRatingsCount",
+    );
+    const unitOfWorkStub = new UnitOfWorkStub();
+    const unitOfWorkExecuteSpy = vi.spyOn(unitOfWorkStub, "execute");
     const sut = new DeleteRateUseCase(
       findPetRepositoryStub,
       deleteRateRepositoryStub,
+      updatePetRatingsCountRepositoryStub,
+      unitOfWorkStub,
     );
 
     return {
       sut,
       findPetRepositorySpy,
       deleteRateRepositorySpy,
+      decrementRatingsCountSpy,
+      unitOfWorkExecuteSpy,
     };
   };
 
@@ -29,6 +44,14 @@ describe("DeleteRateUseCase", () => {
     petId: "valid_pet_id",
     userId: "valid_user_id",
   };
+
+  it("Should run inside UnitOfWork", async () => {
+    const { sut, unitOfWorkExecuteSpy } = makeSut();
+
+    await sut.execute(deleteRateDTO);
+
+    expect(unitOfWorkExecuteSpy).toHaveBeenCalledTimes(1);
+  });
 
   it("Should call FindPetRepository.findById with correct values", async () => {
     const { sut, findPetRepositorySpy } = makeSut();
@@ -57,11 +80,12 @@ describe("DeleteRateUseCase", () => {
     expect(deleteRateRepositorySpy).toHaveBeenCalledWith(
       "valid_pet_id",
       "valid_user_id",
+      {} as Transaction,
     );
   });
 
-  it("Should return deleted when repository removes an existing rate", async () => {
-    const { sut } = makeSut();
+  it("Should decrement ratings_count and return deleted when repository removes an existing rate", async () => {
+    const { sut, decrementRatingsCountSpy } = makeSut();
 
     const result = await sut.execute(deleteRateDTO);
 
@@ -69,10 +93,15 @@ describe("DeleteRateUseCase", () => {
       petId: "valid_pet_id",
       status: "deleted",
     });
+    expect(decrementRatingsCountSpy).toHaveBeenCalledWith(
+      "valid_pet_id",
+      {} as Transaction,
+    );
   });
 
-  it("Should return unchanged when repository does not find a rate to delete", async () => {
-    const { sut, deleteRateRepositorySpy } = makeSut();
+  it("Should return unchanged and avoid decrement when repository does not find a rate to delete", async () => {
+    const { sut, deleteRateRepositorySpy, decrementRatingsCountSpy } =
+      makeSut();
     deleteRateRepositorySpy.mockResolvedValueOnce(false);
 
     const result = await sut.execute(deleteRateDTO);
@@ -81,11 +110,23 @@ describe("DeleteRateUseCase", () => {
       petId: "valid_pet_id",
       status: "unchanged",
     });
+    expect(decrementRatingsCountSpy).not.toHaveBeenCalled();
   });
 
   it("Should rethrow if DeleteRateRepository.deleteByPetIdAndUserId throws an unexpected error", async () => {
     const { sut, deleteRateRepositorySpy } = makeSut();
     deleteRateRepositorySpy.mockRejectedValueOnce(
+      new Error("Unexpected error"),
+    );
+
+    const promise = sut.execute(deleteRateDTO);
+
+    await expect(promise).rejects.toThrow(new Error("Unexpected error"));
+  });
+
+  it("Should rethrow if decrement ratings count throws an unexpected error", async () => {
+    const { sut, decrementRatingsCountSpy } = makeSut();
+    decrementRatingsCountSpy.mockRejectedValueOnce(
       new Error("Unexpected error"),
     );
 

--- a/backend/tests/application/doubles/delete-rate.repository.stub.ts
+++ b/backend/tests/application/doubles/delete-rate.repository.stub.ts
@@ -1,7 +1,12 @@
+import type { Transaction } from "@application/ports/unit-of-work.contract";
 import type { DeleteRateRepository } from "@application/repositories/delete-rate.repository";
 
 export class DeleteRateRepositoryStub implements DeleteRateRepository {
-  async deleteByPetIdAndUserId(): Promise<boolean> {
+  async deleteByPetIdAndUserId(
+    _: string,
+    __: string,
+    ___?: Transaction,
+  ): Promise<boolean> {
     return true;
   }
 }

--- a/backend/tests/application/doubles/rate.repository.stub.ts
+++ b/backend/tests/application/doubles/rate.repository.stub.ts
@@ -20,7 +20,7 @@ export class RateRepositoryStub implements RateRepository {
         createdAt: FIXED_DATE,
         updatedAt: FIXED_DATE,
       },
-      operation: "created",
+      wasCreated: true,
     };
   }
 }

--- a/backend/tests/application/doubles/rate.repository.stub.ts
+++ b/backend/tests/application/doubles/rate.repository.stub.ts
@@ -1,28 +1,26 @@
-import type { RateRepository } from "@application/repositories/rate.repository";
+import type { Transaction } from "@application/ports/unit-of-work.contract";
+import type {
+  RateRepository,
+  UpsertResult,
+} from "@application/repositories/rate.repository";
 import type { Rate } from "@domain/entities/rate";
 import { FIXED_DATE } from "../../config/constants";
 
 export class RateRepositoryStub implements RateRepository {
-  async findByPetIdAndUserId(
-    petId: string,
-    userId: string,
-  ): Promise<Rate | null> {
-    return {
-      petId,
-      userId,
-      rate: "cute",
-      createdAt: FIXED_DATE,
-      updatedAt: FIXED_DATE,
-    };
+  async findByPetIdAndUserId(_: string, __: string): Promise<Rate | null> {
+    return null;
   }
 
-  async upsert(rate: Rate): Promise<Rate> {
+  async upsert(rate: Rate, _: Transaction = {}): Promise<UpsertResult> {
     return {
-      petId: rate.petId,
-      userId: rate.userId,
-      rate: rate.rate,
-      createdAt: FIXED_DATE,
-      updatedAt: FIXED_DATE,
+      rate: {
+        petId: rate.petId,
+        userId: rate.userId,
+        rate: rate.rate,
+        createdAt: FIXED_DATE,
+        updatedAt: FIXED_DATE,
+      },
+      operation: "created",
     };
   }
 }

--- a/backend/tests/application/doubles/update-pet-ratings-count.repository.stub.ts
+++ b/backend/tests/application/doubles/update-pet-ratings-count.repository.stub.ts
@@ -5,4 +5,6 @@ export class UpdatePetRatingsCountRepositoryStub
   implements UpdatePetRatingsCountRepository
 {
   async incrementRatingsCount(_: string, __: Transaction = {}): Promise<void> {}
+
+  async decrementRatingsCount(_: string, __: Transaction = {}): Promise<void> {}
 }

--- a/backend/tests/application/doubles/update-pet-ratings-count.repository.stub.ts
+++ b/backend/tests/application/doubles/update-pet-ratings-count.repository.stub.ts
@@ -1,0 +1,8 @@
+import type { Transaction } from "@application/ports/unit-of-work.contract";
+import type { UpdatePetRatingsCountRepository } from "@application/repositories/update-pet-ratings-count.repository";
+
+export class UpdatePetRatingsCountRepositoryStub
+  implements UpdatePetRatingsCountRepository
+{
+  async incrementRatingsCount(_: string, __: Transaction = {}): Promise<void> {}
+}

--- a/backend/tests/application/rate-pet.usecase.spec.ts
+++ b/backend/tests/application/rate-pet.usecase.spec.ts
@@ -108,7 +108,7 @@ describe("RatePetUseCase", () => {
         createdAt: FIXED_DATE,
         updatedAt: FIXED_DATE,
       },
-      operation: "updated",
+      wasCreated: false,
     });
 
     const result = await sut.execute(ratePetDTO);
@@ -131,7 +131,7 @@ describe("RatePetUseCase", () => {
         createdAt: FIXED_DATE,
         updatedAt: FIXED_DATE,
       },
-      operation: "unchanged",
+      wasCreated: false,
     });
 
     const result = await sut.execute(ratePetDTO);

--- a/backend/tests/application/rate-pet.usecase.spec.ts
+++ b/backend/tests/application/rate-pet.usecase.spec.ts
@@ -1,8 +1,12 @@
 import { AppError } from "@application/errors/app-error";
+import type { Transaction } from "@application/ports/unit-of-work.contract";
 import { RatePetUseCase } from "@application/usecases/rate-pet.usecase";
 import { describe, expect, it, vi } from "vitest";
 import { FindPetRepositoryStub } from "./doubles/find-pet.repository.stub";
 import { RateRepositoryStub } from "./doubles/rate.repository.stub";
+import { UpdatePetRatingsCountRepositoryStub } from "./doubles/update-pet-ratings-count.repository.stub";
+import { UnitOfWorkStub } from "./doubles/unit-of-work.stub";
+import { FIXED_DATE } from "../config/constants";
 
 describe("RatePetUseCase", () => {
   const makeSut = () => {
@@ -10,12 +14,27 @@ describe("RatePetUseCase", () => {
     const findPetRepositorySpy = vi.spyOn(findPetRepositoryStub, "findById");
     const rateRepositoryStub = new RateRepositoryStub();
     const rateRepositoryUpsertSpy = vi.spyOn(rateRepositoryStub, "upsert");
-    const sut = new RatePetUseCase(findPetRepositoryStub, rateRepositoryStub);
+    const updatePetRatingsCountRepositoryStub =
+      new UpdatePetRatingsCountRepositoryStub();
+    const updatePetRatingsCountRepositorySpy = vi.spyOn(
+      updatePetRatingsCountRepositoryStub,
+      "incrementRatingsCount",
+    );
+    const unitOfWorkStub = new UnitOfWorkStub();
+    const unitOfWorkExecuteSpy = vi.spyOn(unitOfWorkStub, "execute");
+    const sut = new RatePetUseCase(
+      findPetRepositoryStub,
+      rateRepositoryStub,
+      updatePetRatingsCountRepositoryStub,
+      unitOfWorkStub,
+    );
 
     return {
       sut,
       findPetRepositorySpy,
       rateRepositoryUpsertSpy,
+      updatePetRatingsCountRepositorySpy,
+      unitOfWorkExecuteSpy,
     };
   };
 
@@ -24,6 +43,14 @@ describe("RatePetUseCase", () => {
     userId: "valid_user_id",
     rate: "majestic" as const,
   };
+
+  it("Should run inside UnitOfWork", async () => {
+    const { sut, unitOfWorkExecuteSpy } = makeSut();
+
+    await sut.execute(ratePetDTO);
+
+    expect(unitOfWorkExecuteSpy).toHaveBeenCalledTimes(1);
+  });
 
   it("Should call FindPetRepository.findById with correct values", async () => {
     const { sut, findPetRepositorySpy } = makeSut();
@@ -49,11 +76,71 @@ describe("RatePetUseCase", () => {
 
     await sut.execute(ratePetDTO);
 
-    expect(rateRepositoryUpsertSpy).toHaveBeenCalledWith({
+    expect(rateRepositoryUpsertSpy).toHaveBeenCalledWith(
+      {
+        petId: "valid_pet_id",
+        userId: "valid_user_id",
+        rate: "majestic",
+      },
+      {} as Transaction,
+    );
+  });
+
+  it("Should increment ratings_count when upsert creates a new rate", async () => {
+    const { sut, updatePetRatingsCountRepositorySpy } = makeSut();
+
+    await sut.execute(ratePetDTO);
+
+    expect(updatePetRatingsCountRepositorySpy).toHaveBeenCalledWith(
+      "valid_pet_id",
+      {} as Transaction,
+    );
+  });
+
+  it("Should not increment ratings_count when upsert updates an existing rate", async () => {
+    const { sut, rateRepositoryUpsertSpy, updatePetRatingsCountRepositorySpy } =
+      makeSut();
+    rateRepositoryUpsertSpy.mockResolvedValueOnce({
+      rate: {
+        petId: "valid_pet_id",
+        userId: "valid_user_id",
+        rate: "majestic",
+        createdAt: FIXED_DATE,
+        updatedAt: FIXED_DATE,
+      },
+      operation: "updated",
+    });
+
+    const result = await sut.execute(ratePetDTO);
+
+    expect(result).toEqual({
       petId: "valid_pet_id",
-      userId: "valid_user_id",
       rate: "majestic",
     });
+    expect(updatePetRatingsCountRepositorySpy).not.toHaveBeenCalled();
+  });
+
+  it("Should not increment ratings_count when upsert returns unchanged", async () => {
+    const { sut, rateRepositoryUpsertSpy, updatePetRatingsCountRepositorySpy } =
+      makeSut();
+    rateRepositoryUpsertSpy.mockResolvedValueOnce({
+      rate: {
+        petId: "valid_pet_id",
+        userId: "valid_user_id",
+        rate: "majestic",
+        createdAt: FIXED_DATE,
+        updatedAt: FIXED_DATE,
+      },
+      operation: "unchanged",
+    });
+
+    const result = await sut.execute(ratePetDTO);
+
+    expect(result).toEqual({
+      petId: "valid_pet_id",
+      rate: "majestic",
+    });
+    expect(updatePetRatingsCountRepositorySpy).not.toHaveBeenCalled();
   });
 
   it("Should return RatePetResult on success", async () => {

--- a/backend/tests/infra/db/postgres/pg-pet.repository.test.ts
+++ b/backend/tests/infra/db/postgres/pg-pet.repository.test.ts
@@ -124,4 +124,58 @@ describe("PgPetRepository", () => {
       expect(petRows.rows[0]?.ratings_count).toBe(1);
     });
   });
+
+  describe("decrementRatingsCount", () => {
+    it("Should decrement ratings_count in the database", async () => {
+      const sut = new PgPetRepository();
+      const pet = await sut.save({
+        ...unsavedPet,
+        petName: "decrement_ratings_count_pet_name",
+      });
+      const pool = PgPool.getInstance();
+      await pool.query(
+        `
+        UPDATE pets
+        SET ratings_count = 2
+        WHERE id = $1
+        `,
+        [pet.id],
+      );
+
+      await sut.decrementRatingsCount(pet.id);
+
+      const petRows = await pool.query<{ ratings_count: number }>(
+        `
+          SELECT ratings_count
+          FROM pets
+          WHERE id = $1
+        `,
+        [pet.id],
+      );
+
+      expect(petRows.rows[0]?.ratings_count).toBe(1);
+    });
+
+    it("Should not decrement ratings_count below zero", async () => {
+      const sut = new PgPetRepository();
+      const pet = await sut.save({
+        ...unsavedPet,
+        petName: "decrement_ratings_count_floor_pet_name",
+      });
+      const pool = PgPool.getInstance();
+
+      await sut.decrementRatingsCount(pet.id);
+
+      const petRows = await pool.query<{ ratings_count: number }>(
+        `
+          SELECT ratings_count
+          FROM pets
+          WHERE id = $1
+        `,
+        [pet.id],
+      );
+
+      expect(petRows.rows[0]?.ratings_count).toBe(0);
+    });
+  });
 });

--- a/backend/tests/infra/db/postgres/pg-pet.repository.test.ts
+++ b/backend/tests/infra/db/postgres/pg-pet.repository.test.ts
@@ -1,5 +1,6 @@
 import { it, describe, expect, beforeAll } from "vitest";
 import { PgPetRepository } from "@infra/db/postgres/pg-pet.repository";
+import { PgPool } from "@infra/db/postgres/helpers/pg-pool";
 import type { UnsavedPet } from "@domain/entities/pet";
 import { insertFakeUser } from "./helpers/fake-user";
 
@@ -97,6 +98,30 @@ describe("PgPetRepository", () => {
 
       const foundPet = await sut.findByIdIncludingDeleted(savedPet.id);
       expect(foundPet?.deleted_at).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("incrementRatingsCount", () => {
+    it("Should increment ratings_count in the database", async () => {
+      const sut = new PgPetRepository();
+      const pet = await sut.save({
+        ...unsavedPet,
+        petName: "increment_ratings_count_pet_name",
+      });
+      const pool = PgPool.getInstance();
+
+      await sut.incrementRatingsCount(pet.id);
+
+      const petRows = await pool.query<{ ratings_count: number }>(
+        `
+          SELECT ratings_count
+          FROM pets
+          WHERE id = $1
+        `,
+        [pet.id],
+      );
+
+      expect(petRows.rows[0]?.ratings_count).toBe(1);
     });
   });
 });

--- a/backend/tests/infra/db/postgres/pg-post.query.test.ts
+++ b/backend/tests/infra/db/postgres/pg-post.query.test.ts
@@ -74,8 +74,7 @@ describe("PgPostQuery", () => {
 
       const result = await sut.findPostDetailsById(post_id);
 
-      expect(result?.ratings).toEqual({
-        total_count: 2,
+      expect(result?.ratings).toMatchObject({
         by_rate: {
           cute: 1,
           funny: 1,

--- a/backend/tests/infra/db/postgres/pg-rate.repository.test.ts
+++ b/backend/tests/infra/db/postgres/pg-rate.repository.test.ts
@@ -25,13 +25,15 @@ describe("PgRateRepository", () => {
     it("Should persist and return a Rate on success", async () => {
       const sut = new PgRateRepository();
 
-      const rate = await sut.upsert(rateDTO);
+      const result = await sut.upsert(rateDTO);
+      const rate = result.rate;
 
       expect(rate.petId).toEqual(rateDTO.petId);
       expect(rate.userId).toEqual(rateDTO.userId);
       expect(rate.rate).toEqual("cute");
       expect(rate.createdAt).toBeInstanceOf(Date);
       expect(rate.updatedAt).toBeInstanceOf(Date);
+      expect(result.wasCreated).toBe(true);
     });
 
     it("Should return a Rate when it exists", async () => {
@@ -129,52 +131,92 @@ describe("PgRateRepository", () => {
 
     it("Should update an existing rate", async () => {
       const sut = new PgRateRepository();
+      await sut.upsert({
+        ...rateDTO,
+        rate: "cute",
+      });
 
-      const updatedRate = await sut.upsert({
+      const result = await sut.upsert({
         ...rateDTO,
         rate: "majestic",
       });
+      const updatedRate = result.rate;
 
       expect(updatedRate.petId).toEqual(rateDTO.petId);
       expect(updatedRate.userId).toEqual(rateDTO.userId);
       expect(updatedRate.rate).toEqual("majestic");
       expect(updatedRate.updatedAt).toBeInstanceOf(Date);
+      expect(result.wasCreated).toBe(false);
+    });
+
+    it("Should upsert a rate inside a transaction", async () => {
+      const sut = new PgRateRepository();
+      const query = vi.fn().mockResolvedValue({
+        rows: [
+          {
+            pet_id: rateDTO.petId,
+            user_id: rateDTO.userId,
+            rate: "funny",
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        ],
+        rowCount: 1,
+      });
+      const transaction = {
+        query,
+      };
+
+      await sut.upsert(
+        {
+          ...rateDTO,
+          rate: "funny",
+        },
+        transaction,
+      );
+      expect(transaction.query).toHaveBeenCalled();
     });
 
     it("Should keep updatedAt unchanged when the same rate is upserted again", async () => {
       const sut = new PgRateRepository();
-      const initialRate = await sut.upsert({
+      const initialResult = await sut.upsert({
         ...rateDTO,
         rate: "smart",
       });
+      const initialRate = initialResult.rate;
 
       await new Promise((resolve) => setTimeout(resolve, 20));
-      const repeatedRate = await sut.upsert({
+      const repeatedResult = await sut.upsert({
         ...rateDTO,
         rate: "smart",
       });
+      const repeatedRate = repeatedResult.rate;
 
       expect(repeatedRate.updatedAt?.getTime()).toBe(
         initialRate.updatedAt?.getTime(),
       );
+      expect(repeatedResult.wasCreated).toBe(false);
     });
 
     it("Should update updatedAt when a different rate is upserted", async () => {
       const sut = new PgRateRepository();
-      const initialRate = await sut.upsert({
+      const initialResult = await sut.upsert({
         ...rateDTO,
         rate: "cute",
       });
+      const initialRate = initialResult.rate;
 
       await new Promise((resolve) => setTimeout(resolve, 20));
-      const updatedRate = await sut.upsert({
+      const updatedResult = await sut.upsert({
         ...rateDTO,
         rate: "funny",
       });
+      const updatedRate = updatedResult.rate;
 
       expect(updatedRate.updatedAt?.getTime()).toBeGreaterThan(
         initialRate.updatedAt?.getTime() ?? 0,
       );
+      expect(updatedResult.wasCreated).toBe(false);
     });
   });
 });

--- a/backend/tests/infra/db/postgres/pg-rate.repository.test.ts
+++ b/backend/tests/infra/db/postgres/pg-rate.repository.test.ts
@@ -177,6 +177,26 @@ describe("PgRateRepository", () => {
       expect(transaction.query).toHaveBeenCalled();
     });
 
+    it("Should delete a rate inside a transaction", async () => {
+      const sut = new PgRateRepository();
+      const query = vi.fn().mockResolvedValue({
+        rows: [],
+        rowCount: 1,
+      });
+      const transaction = {
+        query,
+      };
+
+      const wasDeleted = await sut.deleteByPetIdAndUserId(
+        rateDTO.petId,
+        rateDTO.userId,
+        transaction,
+      );
+
+      expect(wasDeleted).toBe(true);
+      expect(transaction.query).toHaveBeenCalled();
+    });
+
     it("Should keep updatedAt unchanged when the same rate is upserted again", async () => {
       const sut = new PgRateRepository();
       const initialResult = await sut.upsert({

--- a/backend/tests/main/get-post.e2e.test.ts
+++ b/backend/tests/main/get-post.e2e.test.ts
@@ -128,8 +128,7 @@ describe("[E2E] UC-009 GetPost", () => {
     const response = await request(app).get(`/api/posts/${post.toState.id}`);
 
     expect(response.status).toBe(200);
-    expect(response.body.ratings).toEqual({
-      total_count: 3,
+    expect(response.body.ratings).toMatchObject({
       by_rate: {
         cute: 1,
         funny: 2,

--- a/docs/requirements/backend/UC-019-rate-pet.md
+++ b/docs/requirements/backend/UC-019-rate-pet.md
@@ -9,8 +9,8 @@
   - Mood Tags: `cute`, `funny`, `majestic`, `chaos`, `smart`, `sleepy`.
 - [x] The system must allow only **one rating per user per pet**
 - [x] The system must use a toggle based behavior:
-  - If no existing rating exists for (userId, petId): CREATE
-  - If an existing rating exists with a different rate: UPDATE
+  - If no existing rating exists for (userId, petId): CREATE and increment `pets.ratings_count`
+  - If an existing rating exists with a different rate: UPDATE 
   - If an existing rating exists with the same rate: NO-OP (idempotent)
 - [x] The system must persist one user rating with `userId`, `petId`, and `rate`
 - [x] The system must persist timestamps for rating creation and updates (`created_at`, `updated_at`)
@@ -23,6 +23,8 @@
 - [x] The system must enforce uniqueness at db level for (user_id, pet_id) in the ratings table
 - [x] The system must be idempotent for repeated requests (same rate)
 - [x] The system must handle concurrent updates safely (no duplicate ratings)
+- [x] The system must increment `pets.ratings_count` atomically at database level
+- [x] The system must execute the rating write flow inside a UnitOfWork transaction
 
 ## TDD
 

--- a/docs/requirements/backend/UC-020-delete-rate.md
+++ b/docs/requirements/backend/UC-020-delete-rate.md
@@ -7,6 +7,7 @@
 - [x] The system must require a valid and existing `petId`
 - [x] The system must remove the rate only if it exists for the pair `(userId, petId)`
 - [x] The system must perform a **hard delete** of the rate record when it exists
+- [x] The system must decrement `pets.ratings_count` when deleting an existing rate
 - [x] The system must not fail when the user has not rated the pet yet (idempotent no-op)
 - [x] The system must expose the endpoint `DELETE /pets/:id/rate`
 - [x] Happy Path: The system must return **200 OK** with the delete status, e.g.:
@@ -18,6 +19,9 @@
 - [x] The system must be idempotent for repeated delete requests
 - [x] The system must handle concurrent deletes safely (no inconsistent results)
 - [x] The system must preserve database integrity through foreign keys and constraints
+- [x] The system must execute rate delete and `pets.ratings_count` decrement atomically in a UnitOfWork transaction
+- [x] The system must decrement `pets.ratings_count` at database level
+- [x] Repeated delete requests must not decrement `pets.ratings_count` more than once
 
 ## TDD
 


### PR DESCRIPTION
This pull request introduces a new approach for tracking and updating the ratings count for pets by storing the count directly on the `pets` table, rather than calculating it dynamically. It also refactors the `RatePetUseCase` and `DeleteRateUseCase` to ensure ratings count is updated transactionally whenever a pet is rated or a rating is deleted. Several repositories and SQL queries have been updated to support this change, and a migration is added to introduce the new column.

**Database and Data Model Changes:**

* Added a migration to add a `ratings_count` column to the `pets` table, which will store the number of ratings directly for each pet.
* Refactored SQL queries in `feed.query.sql.ts`, `me.query.sql.ts`, `profile.query.sql.ts`, and `post.query.sql.ts` to use the new `ratings_count` column instead of calculating ratings count with joins or subqueries. [[1]](diffhunk://#diff-eb932b588882b30341f26ac4af6f4b547bbf85348aff61427590a61b1b8c275cL10-R10) [[2]](diffhunk://#diff-eb932b588882b30341f26ac4af6f4b547bbf85348aff61427590a61b1b8c275cL29-L33) [[3]](diffhunk://#diff-d424fdae334cbcec61b8fb10ab15b9f5343126500ec927033cdc1c87008e7001L25-L31) [[4]](diffhunk://#diff-b3617a8f6967907c829815888252e37bda22865ccb0dea46efb4bfe1e256bcfeL24-L30) [[5]](diffhunk://#diff-edb53c969f4f101937fda0c8626dbf85fd9b34525b1b5f40b805d638c2f3512bL20-R20) [[6]](diffhunk://#diff-edb53c969f4f101937fda0c8626dbf85fd9b34525b1b5f40b805d638c2f3512bR37-L39)

**Application Logic and Use Case Refactoring:**

* Updated the `RatePetUseCase` and `DeleteRateUseCase` to increment or decrement the `ratings_count` on the pet within a database transaction using a new `UpdatePetRatingsCountRepository` and a `UnitOfWork`. [[1]](diffhunk://#diff-3bded7f771f8ac53f3f63df0c2e4e3b2da799f7492034b028a69166dcac28088R16-R17) [[2]](diffhunk://#diff-3bded7f771f8ac53f3f63df0c2e4e3b2da799f7492034b028a69166dcac28088L23-R44) [[3]](diffhunk://#diff-11881a8c9851094de690dc311132710da62fe8042a4f3820bd25efa501dcbfe0R16-R17) [[4]](diffhunk://#diff-11881a8c9851094de690dc311132710da62fe8042a4f3820bd25efa501dcbfe0R27-R51)
* Factories for these use cases (`rate-pet.usecase.factory.ts` and `delete-rate.usecase.factory.ts`) now inject the necessary repositories and unit of work. [[1]](diffhunk://#diff-ca78ab74f188917ccac83369ffa894c768b03139f11e4d5f9c072d0fe35e1bf3R4-R15) [[2]](diffhunk://#diff-771eb35b0c19e95d396e9750f5a60e98fe5ea0ed5512322b054618dbb6f742a6R4-R15)

**Repository and Interface Changes:**

* Introduced `UpdatePetRatingsCountRepository` interface and implemented it in `PgPetRepository` with `incrementRatingsCount` and `decrementRatingsCount` methods, both supporting transactions. [[1]](diffhunk://#diff-dcbf548ce770039e248f67db02eebeb4bd3d80cc3ea0a6266e1087e2b9c4bc1eR1-R12) [[2]](diffhunk://#diff-b69297c0addb4bdbb86ae8f8184b19e7e8385e2dc0e7bf2808140616c4961b96R6) [[3]](diffhunk://#diff-b69297c0addb4bdbb86ae8f8184b19e7e8385e2dc0e7bf2808140616c4961b96L15-R17) [[4]](diffhunk://#diff-b69297c0addb4bdbb86ae8f8184b19e7e8385e2dc0e7bf2808140616c4961b96R72-R87)
* Updated `RateRepository` and `DeleteRateRepository` interfaces and their Postgres implementations to support transactions and return additional information (e.g., whether a rating was created or updated). [[1]](diffhunk://#diff-9311d6a5fbf0e9ebcf530f56b481f62a21282266d47c7d2d3603b67051ff542bR1-R11) [[2]](diffhunk://#diff-35092253d1a986a7f8eb102bfb0e18e0e2b055ef2df31cc81e7cbefec4d5ac01L2-R15) [[3]](diffhunk://#diff-35092253d1a986a7f8eb102bfb0e18e0e2b055ef2df31cc81e7cbefec4d5ac01L28-R60) [[4]](diffhunk://#diff-1f0bc7a26d44738c07d1b3d5f688a70efe8be508001003a03b229c03604246ebR1-R8)
* Modified the SQL for upserting a rating to return whether the row was newly created, enabling correct incrementing of the ratings count.

**Configuration and Testing:**

* Improved environment variable parsing and typing in `env.ts`. [[1]](diffhunk://#diff-1f7938e59b941e1b0abed39d9de403a0520c50df9ff86a758242f9dcd52d86c4R1-R12) [[2]](diffhunk://#diff-1f7938e59b941e1b0abed39d9de403a0520c50df9ff86a758242f9dcd52d86c4L20-R21)
* Updated tests and stubs to support the new interfaces and transactional logic.

These changes ensure that ratings counts are always accurate and efficiently retrievable, while maintaining consistency through transactional updates.